### PR TITLE
Update projections task

### DIFF
--- a/db/migrate/20191028203752_add_projections_and_injuries_to_players.rb
+++ b/db/migrate/20191028203752_add_projections_and_injuries_to_players.rb
@@ -1,0 +1,7 @@
+class AddProjectionsAndInjuriesToPlayers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :players, :projection_week, :integer
+    add_column :players, :current_projection, :float
+    add_column :players, :injury_status, :string
+  end
+end

--- a/db/migrate/20191028203752_add_projections_and_injuries_to_players.rb
+++ b/db/migrate/20191028203752_add_projections_and_injuries_to_players.rb
@@ -1,7 +1,7 @@
 class AddProjectionsAndInjuriesToPlayers < ActiveRecord::Migration[5.2]
   def change
-    add_column :players, :projection_week, :integer
-    add_column :players, :current_projection, :float
+    add_column :players, :projection_week, :integer, default: 0
+    add_column :players, :current_projection, :float, default: 0
     add_column :players, :injury_status, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_28_020530) do
+ActiveRecord::Schema.define(version: 2019_10_28_203752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,9 @@ ActiveRecord::Schema.define(version: 2019_10_28_020530) do
     t.string "photo_url"
     t.integer "bye_week"
     t.integer "ffn_id"
+    t.integer "projection_week", default: 0
+    t.float "current_projection", default: 0.0
+    t.string "injury_status"
   end
 
   create_table "team_players", force: :cascade do |t|

--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -26,25 +26,11 @@ namespace :update do
       puts "Updated: #{player.display_name} - Week #{data[:week]}"
     end
 
-
-
-
-
-    # current.each do |proj|
-    #   week = proj[:week]
-    #   player = Player.find_by(ffn_id: proj[:ffn_id])
-    #   Player.update(
-    #     projection_week: week,
-    #     current_projection: proj[:projection]
-    #   )
-    #   puts "Updated: #{player.display_name} - Week #{week}"
-    # end
-
     week = Player.maximum(:projection_week)
 
-    Player.where("week < #{week}").each do |player|
-      player.update(week: week, projection: 0)
-      puts "Updated with default: #{player.display_name} - Week #{week}"
+    Player.where("projection_week < #{week}").each do |player|
+      puts "Updating with default: #{player.display_name} - Week #{week}"
+      player.update(projection_week: week, current_projection: 0)
     end
   end
 end

--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -1,0 +1,19 @@
+require 'rake'
+require 'rubygems'
+require 'faraday'
+
+namespace :update do
+  desc 'Update player projections for current week'
+  current_projections.each do |proj|    
+    player = Player.find_by(ffn_id: proj[:ffn_id])
+    Player.update(
+      projection_week: proj[:week],
+      current_projection:proj[:projection]
+    )
+  end
+end
+
+def current_projections
+  response = Faraday.get "https://ff-nerd-service.herokuapp.com/projections/current?key=#{ENV['MY_FF_API_KEY']}"
+  JSON.parse(response.body, symbolize_names: true)
+end

--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -3,17 +3,48 @@ require 'rubygems'
 require 'faraday'
 
 namespace :update do
-  desc 'Update player projections for current week'
-  current_projections.each do |proj|    
-    player = Player.find_by(ffn_id: proj[:ffn_id])
-    Player.update(
-      projection_week: proj[:week],
-      current_projection:proj[:projection]
-    )
-  end
-end
+  desc 'Update player info for current week'
 
-def current_projections
-  response = Faraday.get "https://ff-nerd-service.herokuapp.com/projections/current?key=#{ENV['MY_FF_API_KEY']}"
-  JSON.parse(response.body, symbolize_names: true)
+  task projections: :environment do
+    response = Faraday.get "https://ff-nerd-service.herokuapp.com/projections/current?key=#{ENV['MY_FF_API_KEY']}"
+    current = JSON.parse(response.body, symbolize_names: true)
+
+    ids = current.map { |proj| proj[:ffn_id]}
+    players = Player.where(ffn_id: ids).order(:ffn_id)
+
+    zipped = players.zip(current)
+
+    zipped.each do |info|
+      player = info[0]
+      data = info[1]
+
+      player.update(
+        projection_week: data[:week],
+        current_projection: data[:projection]
+      )
+
+      puts "Updated: #{player.display_name} - Week #{data[:week]}"
+    end
+
+
+
+
+
+    # current.each do |proj|
+    #   week = proj[:week]
+    #   player = Player.find_by(ffn_id: proj[:ffn_id])
+    #   Player.update(
+    #     projection_week: week,
+    #     current_projection: proj[:projection]
+    #   )
+    #   puts "Updated: #{player.display_name} - Week #{week}"
+    # end
+
+    week = Player.maximum(:projection_week)
+
+    Player.where("week < #{week}").each do |player|
+      player.update(week: week, projection: 0)
+      puts "Updated with default: #{player.display_name} - Week #{week}"
+    end
+  end
 end


### PR DESCRIPTION
### rake update:projections
- Calls microservice at `https://ff-nerd-service.herokuapp.com/projections/current` to retrieve projections for current week
- Finds all players in database whose ids are in the current projections
- Updates those players accordingly

- For players who were not in the recent projections, update their current week with a projection of 0.