### PR TITLE
Unverified restriction

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -250,7 +250,10 @@ input[type='submit']:hover,
 
 .search-player {
   margin: 2% 25%;
-  width: 100%;
+}
+
+.search-player input[type=text] {
+  width: 70%;
 }
 
 .size-2 {

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -3,8 +3,7 @@ class Admin::BaseController < ApplicationController
 
   def require_admin
     unless current_admin?
-      flash[:error] = "You are not authorized to see this content."
-      redirect_to root_path
+      render file: 'public/404', status: 404
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,4 +25,9 @@ class ApplicationController < ActionController::Base
       redirect_to profile_path
     end
   end
+
+  rescue_from ActionController::RoutingError do |exception|
+    logger.error "Routing error: #{exception.failures.first}"
+    render file: 'public/404', status: 404
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,9 +2,14 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   helper_method :current_user
+  helper_method :verified_user?
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
+  end
+
+  def verified_user?
+    current_user && current_user.verified
   end
 
   def require_user
@@ -12,5 +17,9 @@ class ApplicationController < ActionController::Base
       flash[:error] = "Please sign in to see this content."
       redirect_to root_path
     end
+  end
+
+  def require_verified_user
+    
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,12 +14,15 @@ class ApplicationController < ActionController::Base
 
   def require_user
     if current_user.nil?
-      flash[:error] = "Please sign in to see this content."
+      flash[:error] = 'Please sign in to see this content.'
       redirect_to root_path
     end
   end
 
   def require_verified_user
-    
+    unless verified_user?
+      flash[:error] = 'Please verify your account to see this content.'
+      redirect_to profile_path
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-<<<<<<< HEAD
   def require_verified_user
     unless verified_user?
       flash[:error] = 'Please verify your account to see this content.'
@@ -26,12 +25,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def current_admin?
+    current_user && current_user.admin?
+  end
+
   rescue_from ActionController::RoutingError do |exception|
     logger.error "Routing error: #{exception.failures.first}"
     render file: 'public/404', status: 404
-=======
-  def current_admin?
-    current_user && current_user.admin?
->>>>>>> c32084c728bca9100650609277a15e37028e65c6
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,4 @@
 class HomeController < ApplicationController
-
   def index
   end
-  
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,8 @@
 class HomeController < ApplicationController
   def index
   end
+
+  def catch_404
+    raise ActionController::RoutingError.new(params[:path], failures = [params[:path]])
+  end
 end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -1,5 +1,5 @@
 class PlayersController < ApplicationController
-  before_action :require_user
+  before_action :require_user, :require_verified_user
 
   def index
     @players = Player.search(params[:search])
@@ -8,7 +8,4 @@ class PlayersController < ApplicationController
   def show
     @player = Player.find(params[:id])
   end
-
-private
-
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,4 @@
 class SessionsController < ApplicationController
-
   def create
     @user = User.find_or_create_from_auth_hash(request.env["omniauth.auth"])
     session[:user_id] = @user.id
@@ -16,7 +15,8 @@ class SessionsController < ApplicationController
     redirect_to root_path
   end
 
-private
+  private
+
   def server_origin
     request.env["HTTP_HOST"]
   end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,6 +1,6 @@
 class StatsController < ApplicationController
-  before_action :require_user
-  
+  before_action :require_user, :require_verified_user
+
   def index
   end
 end

--- a/app/controllers/user/team_players_controller.rb
+++ b/app/controllers/user/team_players_controller.rb
@@ -1,5 +1,5 @@
 class User::TeamPlayersController < ApplicationController
-  before_action :require_user
+  before_action :require_user, :require_verified_user
   skip_before_action :verify_authenticity_token, only: [:create]
 
   def destroy
@@ -27,10 +27,9 @@ class User::TeamPlayersController < ApplicationController
     redirect_back(fallback_location: root_path)
   end
 
-private
+  private
 
   def team_player_params
     params.permit(:team_id, :myPlayer, :id)
   end
-
 end

--- a/app/controllers/user/teams_controller.rb
+++ b/app/controllers/user/teams_controller.rb
@@ -1,5 +1,5 @@
 class User::TeamsController < ApplicationController
-  before_action :require_user
+  before_action :require_verified_user
   before_action :check_user_teams, except: [:index, :new, :create]
 
   def index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,6 @@
 class UsersController < ApplicationController
   before_action :require_user
 
-    # this might be refactored into facade later
   def show
     @user = current_user
     @teams = current_user.teams
@@ -25,7 +24,7 @@ class UsersController < ApplicationController
     flash[:success] = "Thank you! Your account has been activated."
   end
 
-private
+  private
 
   def user_params
     params.require(:user).permit(:email, :user_name)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :require_user
+  before_action :require_verified_user, only: [:edit, :update]
 
   def show
     @user = current_user

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,16 +1,19 @@
 <h1 class="profile-header">My Profile</h1>
-  <section class="user-info">
-    <% if @user.verified? %>
-      <p>Name: <b><%= "#{@user.first_name} #{@user.last_name}" %></b></p>
-      <p>Username: <b><%= @user.user_name %></b></p>
-      <p>Email: <b><%= @user.email %></b></p>
-      <p>Verified &#10004;</p>
-    <% else %>
-      <h5>This account has not been verified.  Please check your email.</h5>
-    <% end %>
-  </section>
+<section class="user-info">
+  <% if verified_user? %>
+    <p>Name: <b><%= "#{@user.first_name} #{@user.last_name}" %></b></p>
+    <p>Username: <b><%= @user.user_name %></b></p>
+    <p>Email: <b><%= @user.email %></b></p>
+    <p>Verified &#10004;</p>
+  <% else %>
+    <h5>This account has not been verified.  Please check your email at <b><%= @user.email %></b></h5>
+  <% end %>
+</section>
+
+<% if verified_user? %>
   <div class="btn-container">
     <%= link_to 'Edit Profile', edit_user_path(@user), class: 'reg-btn' %>
   </div>
 
-<%= render 'partials/team' %>
+  <%= render 'partials/team' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,6 @@ Rails.application.routes.draw do
 
   get '/profile', to: 'users#show'
   get '/verification/:user_id', to: 'users#verify'
+
+  match "*path", to: "home#catch_404", via: :all
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     last_name { "Ditka" }
     picture { "MyString" }
     user_name { 'mikey' }
+    verified { true }
   end
 end

--- a/spec/features/users/user_authorization_spec.rb
+++ b/spec/features/users/user_authorization_spec.rb
@@ -9,7 +9,6 @@ describe 'As a logged in user' do
   scenario 'I cannot view the admin dashboard' do
     visit admin_users_path
 
-    expect(current_path).to eq root_path
-    expect(page).to have_content("You are not authorized to see this content.")
+    expect(page).to have_content("The page you were looking for doesn't exist.")
   end
 end

--- a/spec/features/users/user_email_verification_spec.rb
+++ b/spec/features/users/user_email_verification_spec.rb
@@ -8,7 +8,7 @@ describe 'email verification' do
 
     user = User.last
     expect(user.verified).to eq(false)
-    expect(page).to have_content('This account has not been verified. Please check your email.')
+    expect(page).to have_content('This account has not been verified. Please check your email at alec@gmail.com')
 
     visit "verification/#{user.id}"
     user = User.last

--- a/spec/features/users/users_must_verify_email_before_accessing_content_spec.rb
+++ b/spec/features/users/users_must_verify_email_before_accessing_content_spec.rb
@@ -17,6 +17,13 @@ describe 'As a new user' do
       expect(page).to_not have_css('.teams')
     end
 
+    scenario 'I cannot edit my profile' do
+      visit edit_user_path(@user)
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content('Please verify your account to see this content.')
+    end
+
     scenario 'I cannot visit "My Teams"' do
       visit user_teams_path
 

--- a/spec/features/users/users_must_verify_email_before_accessing_content_spec.rb
+++ b/spec/features/users/users_must_verify_email_before_accessing_content_spec.rb
@@ -18,7 +18,10 @@ describe 'As a new user' do
     end
 
     scenario 'I cannot visit "My Teams"' do
-      
+      visit user_teams_path
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content('Please verify your account to see this content.')
     end
   end
 end

--- a/spec/features/users/users_must_verify_email_before_accessing_content_spec.rb
+++ b/spec/features/users/users_must_verify_email_before_accessing_content_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'As a new user' do
+  context 'I have not verified my email yet' do
+    before :each do
+      @user = create(:user, verified: false)
+      allow_any_instance_of(ApplicationController)
+        .to receive(:current_user).and_return(@user)
+    end
+
+    scenario 'I can access my profile, but it tells me to check my email' do
+      visit profile_path
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content(@user.email)
+      expect(page).to_not have_link('Edit Profile')
+      expect(page).to_not have_css('.teams')
+    end
+
+    scenario 'I cannot visit "My Teams"' do
+      
+    end
+  end
+end

--- a/spec/features/users/users_must_verify_email_before_accessing_content_spec.rb
+++ b/spec/features/users/users_must_verify_email_before_accessing_content_spec.rb
@@ -23,5 +23,19 @@ describe 'As a new user' do
       expect(current_path).to eq(profile_path)
       expect(page).to have_content('Please verify your account to see this content.')
     end
+
+    scenario 'I cannot visit player index or show pages' do
+      visit players_path
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content('Please verify your account to see this content.')
+
+      player = create(:player)
+
+      visit player_path(player)
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content('Please verify your account to see this content.')
+    end
   end
 end

--- a/spec/features/users/users_must_verify_email_before_accessing_content_spec.rb
+++ b/spec/features/users/users_must_verify_email_before_accessing_content_spec.rb
@@ -37,5 +37,12 @@ describe 'As a new user' do
       expect(current_path).to eq(profile_path)
       expect(page).to have_content('Please verify your account to see this content.')
     end
+
+    scenario 'I cannot visit the league stats page' do
+      visit leaguestats_path
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content('Please verify your account to see this content.')
+    end
   end
 end

--- a/spec/features/visiting_nonexistant_path_renders_404_spec.rb
+++ b/spec/features/visiting_nonexistant_path_renders_404_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'As a user' do
+  context 'I type in any route that is not an actual route' do
+    scenario 'I see a 404 error message' do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController)
+        .to receive(:current_user).and_return(user)
+
+      visit '/this_is_not_a_path'
+
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+  end
+end

--- a/spec/features/visitors/visitor_authorization_spec.rb
+++ b/spec/features/visitors/visitor_authorization_spec.rb
@@ -4,7 +4,6 @@ describe 'As a visitor' do
   scenario 'I cannot view the admin dashboard' do
     visit admin_users_path
 
-    expect(current_path).to eq root_path
-    expect(page).to have_content("You are not authorized to see this content.")
+    expect(page).to have_content("The page you were looking for doesn't exist.")
   end
 end

--- a/spec/features/visitors/visitor_can_register_with_google_spec.rb
+++ b/spec/features/visitors/visitor_can_register_with_google_spec.rb
@@ -9,7 +9,7 @@ describe 'Visitor can register' do
 
     click_link "Sign in with Google"
 
-    expect(page).to have_content("This account has not been verified. Please check your email.")
+    expect(page).to have_content("This account has not been verified. Please check your email at alec@gmail.com")
     expect(page).to have_link("Logout")
 
     click_link 'Logout'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,8 +67,8 @@ describe User, type: :model do
   end
 
   it 'instance methods' do
-    new_user = create(:user, user_name: 'fft')
-    verified_user = create(:user, user_name: 'fft', verified: true)
+    new_user = User.create(user_name: 'fft')
+    verified_user = User.create(user_name: 'fft', verified: true)
 
     expect(new_user.verified?).to eq(false)
     expect(verified_user.verified?).to eq(true)


### PR DESCRIPTION
### Major Changes
- Users who have authenticated with google, but who have not verified their email can only view their profile, but only see a message to check their email.
- They may not visit:
    - players index or show page
    - 'My Teams' page or any team crud pages
    - Profile edit page
    - league stats page

### Minor changes
- Fixed any tests associated with these changes
- Fixed width of player-search form on players index to hopefully render correctly in production
- Added a route matcher to render 404 for any mistyped route
- Changed from 'redirect and flash message' to 'render 404' when trying to visit admin pages (so it looks the same as any other mistyped route.