### PR TITLE
Player Bio Page- Weekly Projections

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -214,6 +214,15 @@ tr:nth-child(even) {
   text-align: center;
 }
 
+.players-projection-table {
+  font-size: 1.7em;
+  table-layout: auto;
+  width: 50%;
+  margin: 2%;
+  text-align: center;
+  border: 3px solid #563d7c;
+}
+
 .users-table {
   font-size: 1.7em;
   table-layout: fixed;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -244,7 +244,6 @@ tr:nth-child(even) {
   text-align: center;
 }
 
-
 .players-projection-table {
   font-size: 1.7em;
   table-layout: auto;

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -2,8 +2,6 @@ class PlayersController < ApplicationController
   before_action :require_user, :require_verified_user
   helper_method :sort_column, :sort_direction
 
-
-  
   def index
     if params[:position]
       @players = Player.search_position(params[:position]).order(current_projection: :desc)
@@ -19,6 +17,7 @@ class PlayersController < ApplicationController
 
   def show
     @player = Player.find(params[:id])
+    @projections = UpdateService.new.get_all_projections(@player)
   end
 
   private

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -41,4 +41,22 @@ class Player < ApplicationRecord
   def current_team_player(team)
     team_players.find_by(team_id: team.id)
   end
+
+  def weekly_projections_array(projections)
+    weeks = (1..self.projection_week).to_a
+    weeks.map do |week_number|
+      if projections.select{ |proj| proj[:week] == week_number }.empty?
+        [week_number, 0.0]
+      else
+        projection = projections.select{ |proj| proj[:week] == week_number }.first
+        [week_number, projection[:projection]]
+      end
+    end
+  end
+
+  def total_year_projection(projections)
+    projections.sum do |proj|
+      proj[:projection]
+    end
+  end
 end

--- a/app/services/update_service.rb
+++ b/app/services/update_service.rb
@@ -35,4 +35,9 @@ class UpdateService
       player.update(projection_week: week, current_projection: 0)
     end
   end
+
+  def get_all_projections(player)
+    response = fetch("all_player_projections/#{player.ffn_id}")
+    JSON.parse(response.body, symbolize_names: true)
+  end
 end

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -75,3 +75,26 @@
     </tbody>
   </table>
 <% end %>
+
+<center>
+  <table class="players-projection-table">
+    <thead class="thead-players">
+      <tr>
+        <th scope="col">Week</th>
+        <th scope="col">Projected Points</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @player.weekly_projections_array(@projections).each do |proj| %>
+        <tr>
+          <td><%= proj[0] %></td>
+          <td><%= proj[1] %></td>
+        </tr>
+      <% end %>
+      <tr>
+        <td>Total</td>
+        <td><%= @player.total_year_projection(@projections) %></td>
+      </tr>
+    </tbody>
+  </table>
+</center>

--- a/fixtures/projection_data.json
+++ b/fixtures/projection_data.json
@@ -1,0 +1,47 @@
+[
+    {
+        "week": 1,
+        "ffn_id": 13,
+        "projection": 18.67
+    },
+    {
+        "week": 2,
+        "ffn_id": 13,
+        "projection": 21.05
+    },
+    {
+        "week": 3,
+        "ffn_id": 13,
+        "projection": 20.24
+    },
+    {
+        "week": 4,
+        "ffn_id": 13,
+        "projection": 17.33
+    },
+    {
+        "week": 5,
+        "ffn_id": 13,
+        "projection": 19.12
+    },
+    {
+        "week": 6,
+        "ffn_id": 13,
+        "projection": 19.77
+    },
+    {
+        "week": 7,
+        "ffn_id": 13,
+        "projection": 17.94
+    },
+    {
+        "week": 8,
+        "ffn_id": 13,
+        "projection": 19.37
+    },
+    {
+        "week": 9,
+        "ffn_id": 13,
+        "projection": 19.18
+    }
+]

--- a/spec/features/players/player_show_spec.rb
+++ b/spec/features/players/player_show_spec.rb
@@ -25,6 +25,16 @@ describe 'Players' do
       .to_return(status: 200, body: @json_projections)
   end
 
+  it ' user can get to the player show page through the link in the team page' do
+    team_player = @team_1.team_players.create(player: @tom_brady)
+
+    visit user_team_path(@team_1)
+
+    click_link("Tom Brady")
+
+    expect(current_path).to eq player_path(@tom_brady)
+  end
+
   it ' user can view player show page' do
     visit player_path(@tom_brady)
 

--- a/spec/features/players/player_show_spec.rb
+++ b/spec/features/players/player_show_spec.rb
@@ -15,9 +15,14 @@ describe 'Players' do
               experience: "20th season",
               birth_date: "October 31, 1976",
               height: "6-4",
-              weight: 220
+              weight: 220,
+              ffn_id: 13
             )
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+
+    @json_projections = File.open('./fixtures/projection_data.json')
+    stub_request(:get, "https://ff-nerd-service.herokuapp.com/all_player_projections/13?key=#{ENV['MY_FF_API_KEY']}")
+      .to_return(status: 200, body: @json_projections)
   end
 
   it ' user can view player show page' do
@@ -44,7 +49,7 @@ describe 'Players' do
     within('.dropdown-menu') do
       click_on("Not team 2")
     end
-    
+
     expect(current_path).to eq player_path(@tom_brady)
     expect(page).to have_content("Tom Brady has been added to your team!")
 

--- a/spec/features/users/user_team_show_page_spec.rb
+++ b/spec/features/users/user_team_show_page_spec.rb
@@ -23,9 +23,7 @@ describe "A logged in user on a team show page" do
   scenario "can click a player name to go to the player show page" do
     visit user_team_path(@team_1)
 
-    click_link("Frank Gore")
-
-    expect(current_path).to eq player_path(@player_1)
+    expect(page).to have_link("Frank Gore")
   end
 
   scenario "can remove a player from the team" do

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -61,5 +61,28 @@ describe Player, type: :model do
 
       expect(player.defense_photo_url).to eq defense.photo_url
     end
+
+    it '#weekly_projections_array' do
+      player = create(:player,
+            bye_week: 7,
+            projection_week: 9
+          )
+
+      projections = [{week: 2, projection: 3.6}, {week: 5, projection: 10.77}]
+      expected = [[1, 0.0], [2, 3.6], [3, 0.0], [4, 0.0], [5, 10.77], [6, 0.0], [7, 0.0], [8, 0.0], [9, 0.0]]
+
+      expect(player.weekly_projections_array(projections)).to eq expected
+    end
+
+    it '#total_year_projection' do
+      player = create(:player,
+            bye_week: 7,
+            projection_week: 9
+          )
+
+      projections = [{week: 2, projection: 3.6}, {week: 5, projection: 10.77}]
+
+      expect(player.total_year_projection(projections)).to eq 14.37
+    end
   end
 end


### PR DESCRIPTION
-  Player show page displays the projections for the player by week and a total to this point in the season
    - 2 new player instance methods are used to display this in the view
    - 1 new update_service method to call a different api endpoint

- Minor styling additions for this feature

-  Model testing
-  Feature tests updated using a stubbed call for the player show page